### PR TITLE
Fix game joining user errors caused by lower case letters

### DIFF
--- a/lib/leafblower_web/controllers/game_live.ex
+++ b/lib/leafblower_web/controllers/game_live.ex
@@ -208,7 +208,7 @@ defmodule LeafblowerWeb.GameLive do
     }
 
     ~H"""
-    <pre>Game code: <b><%= @game_id %></b><br/>Share it with your fiends to play!</pre>
+    <pre>Game code: <b><%= @game_id %></b><br/>Share it with your friends to play!</pre>
     <%= if @is_leader? do%>
       <button phx-click="start_round" {[disabled: @disabled]}>Start Game</button>
     <% end %>

--- a/lib/leafblower_web/controllers/game_splash_live.ex
+++ b/lib/leafblower_web/controllers/game_splash_live.ex
@@ -68,7 +68,7 @@ defmodule LeafblowerWeb.GameSplashLive do
   def handle_event("join_by_code", %{"code" => params}, socket) do
      {:noreply,
      socket
-     |> push_redirect(to: Routes.live_path(socket, LeafblowerWeb.GameLive, params["code"]), replace: true)}
+     |> push_redirect(to: Routes.live_path(socket, LeafblowerWeb.GameLive, String.upcase(params["code"])), replace: true)}
   end
 
   @impl true
@@ -87,7 +87,7 @@ defmodule LeafblowerWeb.GameSplashLive do
   def render(%{page: :join_by_code} = assigns) do
     ~H"""
       <.form let={f} for={@changeset} phx-change="validate_code" phx-submit="join_by_code" as="code">
-        <%= text_input f, :code, placeholder: "Enter game code!" %>
+        <%= text_input f, :code, placeholder: "Enter game code!", style: "text-transform:uppercase" %>
         <%= error_tag f, :code %>
 
         <%= submit "Find game", [disabled: length(@changeset.errors) > 0] %>


### PR DESCRIPTION
Capitalise the game code when redirecting to the game, such as reading out the code over a video or voice bridge.

Not so sure about styling the field to only display upper case versions of the game code. Perhaps too hacky to add it as an in-line style?